### PR TITLE
Dourado can appear after Penetracao

### DIFF
--- a/cincomancia.html
+++ b/cincomancia.html
@@ -199,7 +199,6 @@ function setJogoRules(jogo) {
     ex(TesouroEscondido, [TeleporteOutro,Polimorfo,UrdiduraDoTempo,Colecao]);
     ex(OPilar, [RaizEsquerda,Colecao]);
     ex(Dourado, [Golias,RaizEsquerda,Colecao]);
-    ex(Penetracao, [Dourado]);
     ex(Envolver, [Duplicar]);
     ex(RaioCurto, [Golias,CamaraoNovo,Dourado]);
     ex(Instante, [Adicional]);
@@ -295,7 +294,6 @@ function setJogoRules(jogo) {
     ex(TesouroEscondido, [TeleporteOutro,Polimorfo,UrdiduraDoTempo,Colecao,RaioCurto]);
     ex(OPilar, [Colecao]);
     ex(Dourado, [UrdiduraDoTempo,Colecao]);
-    ex(Penetracao, [Dourado]);
     ex(RaioCurto, [Reflexao]);
     ex(Instante, [Adicional]);
     ex(Identificar, [Esquecer]);

--- a/noresize.html
+++ b/noresize.html
@@ -196,7 +196,6 @@ function setJogoRules(jogo) {
     ex(TesouroEscondido, [TeleporteOutro,Polimorfo,UrdiduraDoTempo,Colecao]);
     ex(OPilar, [RaizEsquerda,Colecao]);
     ex(Dourado, [Golias,RaizEsquerda,Colecao]);
-    ex(Penetracao, [Dourado]);
     ex(Envolver, [Duplicar]);
     ex(RaioCurto, [Golias,CamaraoNovo,Dourado]);
     ex(Instante, [Adicional]);
@@ -292,7 +291,6 @@ function setJogoRules(jogo) {
     ex(TesouroEscondido, [TeleporteOutro,Polimorfo,UrdiduraDoTempo,Colecao,RaioCurto]);
     ex(OPilar, [Colecao]);
     ex(Dourado, [UrdiduraDoTempo,Colecao]);
-    ex(Penetracao, [Dourado]);
     ex(RaioCurto, [Reflexao]);
     ex(Instante, [Adicional]);
     ex(Identificar, [Esquecer]);


### PR DESCRIPTION
During play, I've discovered that Dourado can appear after Penetracao (I had a wand with Poison, Pass Through, Additional, Dorado, and Thorns in that order, without Forget getting involved), so I've updated Cincomancia to match.